### PR TITLE
Added Node.js Exit Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Want to contribute? Great! First, [read this page][].
 * [C][]
 * Go
 * Java
-* JavaScript
+* [JavaScript][]
+  * [NODEJS][]
 * [PHP][]
   * [PHP-XML][] 
 * [Python][]
@@ -79,3 +80,5 @@ MIT see [LICENSE][] for the full license text.
    [PHP]: https://github.com/arzzen/all-exit-error-codes/tree/master/programming-languages/php
    [PHP-XML]: https://github.com/arzzen/all-exit-error-codes/blob/master/programming-languages/php/xml.md
    [C]: https://github.com/arzzen/all-exit-error-codes/blob/master/programming-languages/c/errors.md
+   [JavaScript]: https://github.com/arzzen/all-exit-error-codes/blob/master/programming-languages/javascript
+   [NODEJS]: https://github.com/arzzen/all-exit-error-codes/blob/master/programming-languages/javascript/nodejs.md

--- a/programming-languages/javascript/nodejs.md
+++ b/programming-languages/javascript/nodejs.md
@@ -1,0 +1,19 @@
+# Node.js Exit Codes
+
+This list comes directly from [Nodejs.org's exit codes](https://nodejs.org/api/process.html#process_exit_codes).
+
+| Error Number  | Error Code    | Description  |
+| :-------------: |:-------------| ------------|
+| 0 | N/A | Node.js will normally exit with a 0 status code when no more async operations are pending.|
+| 1 | Uncaught Fatal Exception | There was an uncaught exception, and it was not handled by a domain or an 'uncaughtException' event handler.  |
+| 2 | N/A | Reserved by Bash for builtin misuse |
+| 3 | Internal JavaScript Parse Error | The JavaScript source code internal in Node.js's bootstrapping process caused a parse error. This is extremely rare, and generally can only happen during development of Node.js itself. |
+| 4 | Internal JavaScript Evaluation Failure | The JavaScript source code internal in Node.js's bootstrapping process failed to return a function value when evaluated. This is extremely rare, and generally can only happen during development of Node.js itself. |
+| 5 | Fatal Error | There was a fatal unrecoverable error in V8. Typically a message will be printed to stderr with the prefix FATAL ERROR. |
+| 6 | Non-function Internal Exception Handler | There was an uncaught exception, but the internal fatal exception handler function was somehow set to a non-function, and could not be called. |
+| 7 | Internal Exception Handler Run-Time Failure | There was an uncaught exception, and the internal fatal exception handler function itself threw an error while attempting to handle it. This can happen, for example, if a 'uncaughtException' or domain.on('error') handler throws an error. |
+| 8 | N/A | In previous versions of Node.js, exit code 8 sometimes indicated an uncaught exception. |
+| 9 | Invalid Argument | Either an unknown option was specified, or an option requiring a value was provided without a value. |
+| 10 | Internal JavaScript Run-Time Failure | The JavaScript source code internal in Node.js's bootstrapping process threw an error when the bootstrapping function was called. This is extremely rare, and generally can only happen during development of Node.js itself. |
+| 12 | Invalid Debug Argument | The --debug, --inspect and/or --debug-brk options were set, but the port number chosen was invalid or unavailable. |
+| >128 | Signal Exits | If Node.js receives a fatal signal such as SIGKILL or SIGHUP, then its exit code will be 128 plus the value of the signal code. This is a standard Unix practice, since exit codes are defined to be 7-bit integers, and signal exits set the high-order bit, and then contain the value of the signal code. |


### PR DESCRIPTION
Put Node.js exit codes into a readable table. Consists of error numbers, codes and the description of each. I went ahead and changed the links in the Readme assuming that this format is okay.
